### PR TITLE
Enforces trailing slash on all requests

### DIFF
--- a/tests/client/test_HttpClient.py
+++ b/tests/client/test_HttpClient.py
@@ -108,7 +108,7 @@ class BaseHttpMethodTests:
     client_method_name: str
     client_method_args: dict[str, str]
     request_type: str
-    request_endpoint = "test/endpoint"
+    request_endpoint = "test/endpoint/"
 
     def setUp(self) -> None:
         """Set a client instance for each test case."""

--- a/tests/client/test_KeystoneClient.py
+++ b/tests/client/test_KeystoneClient.py
@@ -45,7 +45,7 @@ class Create(TestCase):
         """Delete any test records."""
 
         for cluster in self.client.http_get(f'allocations/clusters/', params={'name': 'Test-Cluster'}).json():
-            self.client.http_delete(f"allocations/clusters/{cluster['id']}").raise_for_status()
+            self.client.http_delete(f"allocations/clusters/{cluster['id']}/").raise_for_status()
 
     def test_record_is_created(self) -> None:
         """Test a record is created successfully."""
@@ -56,7 +56,7 @@ class Create(TestCase):
         )
 
         pk = new_record_data['id']
-        self.client.http_get(f'allocations/clusters/{pk}').raise_for_status()
+        self.client.http_get(f'allocations/clusters/{pk}/').raise_for_status()
 
     def test_record_data_matches_request(self) -> None:
         """Test the returned record data matches the request."""
@@ -102,10 +102,10 @@ class Retrieve(TestCase):
         """Delete any test records."""
 
         for cluster in self.client.http_get(f'allocations/clusters/', params={'name': 'Test-Cluster'}).json():
-            self.client.http_delete(f"allocations/clusters/{cluster['id']}").raise_for_status()
+            self.client.http_delete(f"allocations/clusters/{cluster['id']}/").raise_for_status()
 
         for cluster in self.client.http_get(f'allocations/clusters/', params={'name': 'Other-Cluster'}).json():
-            self.client.http_delete(f"allocations/clusters/{cluster['id']}").raise_for_status()
+            self.client.http_delete(f"allocations/clusters/{cluster['id']}/").raise_for_status()
 
     def test_retrieve_by_pk(self) -> None:
         """Test the retrieval of a specific record via its primary key."""
@@ -165,7 +165,7 @@ class Update(TestCase):
         """Delete any test records."""
 
         for cluster in self.client.http_get(f'allocations/clusters/', params={'name': 'Test-Cluster'}).json():
-            self.client.http_delete(f"allocations/clusters/{cluster['id']}").raise_for_status()
+            self.client.http_delete(f"allocations/clusters/{cluster['id']}/").raise_for_status()
 
     def test_update_record(self) -> None:
         """Test the record is updated successfully."""
@@ -225,7 +225,7 @@ class Delete(TestCase):
         """Delete any test records."""
 
         for cluster in self.client.http_get(f'allocations/clusters/', params={'name': 'Test-Cluster'}).json():
-            self.client.http_delete(f"allocations/clusters/{cluster['id']}").raise_for_status()
+            self.client.http_delete(f"allocations/clusters/{cluster['id']}/").raise_for_status()
 
     def test_delete_record(self) -> None:
         """Test a record is deleted successfully."""


### PR DESCRIPTION
Fixes bug where some requests are missing the trailing slash in the URL path. This results in a 301 redirect from the API server, which adds unnecessary overhead.