### PR TITLE
Drops explicit cleanup on del

### DIFF
--- a/keystone_client/http.py
+++ b/keystone_client/http.py
@@ -115,9 +115,6 @@ class HTTPClient(HTTPBase):
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
 
-    def __del__(self) -> None:
-        self.close()
-
     def _client_factory(self, **kwargs) -> httpx.Client:
         """Create a new HTTP client instance with the provided settings."""
 
@@ -270,14 +267,6 @@ class AsyncHTTPClient(HTTPBase):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         await self.close()
-
-    def __del__(self) -> None:
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self._client.aclose())
-        except RuntimeError:
-            # No running loop; can't close asynchronously
-            pass
 
     def _client_factory(self, **kwargs) -> httpx.AsyncClient:
         """Create a new HTTP client instance with the provided settings."""

--- a/keystone_client/http.py
+++ b/keystone_client/http.py
@@ -7,7 +7,6 @@ URL normalization, session management, and CSRF token handling.
 """
 
 import abc
-import asyncio
 import re
 import uuid
 from typing import Optional, Union

--- a/tests/unit_tests/test_http/test_AsyncHTTPClient.py
+++ b/tests/unit_tests/test_http/test_AsyncHTTPClient.py
@@ -33,16 +33,6 @@ class CloseMethodAsync(IsolatedAsyncioTestCase):
 
         mock_httpx_class.return_value.aclose.assert_called_once()
 
-    async def test_close_on_delete(self, mock_httpx_class: MagicMock) -> None:
-        """Verify any open sessions are closed when deleting an instance."""
-
-        mock_httpx_class.return_value.aclose = AsyncMock()
-
-        client = AsyncHTTPClient(base_url="https://example.com")
-        del client
-
-        mock_httpx_class.return_value.aclose.assert_called_once()
-
 
 class SendRequestMethodAsync(IsolatedAsyncioTestCase):
     """Test HTTP requests issued by the `send_requests` method."""

--- a/tests/unit_tests/test_http/test_HTTPClient.py
+++ b/tests/unit_tests/test_http/test_HTTPClient.py
@@ -29,14 +29,6 @@ class CloseMethod(TestCase):
 
         mock_httpx_class.return_value.close.assert_called_once()
 
-    def test_close_on_delete(self, mock_httpx_class: MagicMock) -> None:
-        """Verify any open sessions are closed when deleting an instance."""
-
-        client = HTTPClient(base_url="https://example.com")
-        del client
-
-        mock_httpx_class.return_value.close.assert_called_once()
-
 
 class SendRequestMethod(TestCase):
     """Test HTTP requests issued by the `send_requests` method."""


### PR DESCRIPTION
Drops the wrapping of asynchronous cleanup in `__del__`. Since Python `del` is only synchronous, this can cause problems when an object is cleaned up outside the event loop.