### PR TITLE
Adds HTTP response codes to application logs

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -21,13 +21,14 @@ logging.getLogger('kclient').addHandler(handler)
 In addition to Python's built-in message fields, the `kclient` logger also exposes the following package-specific values.
 These fields are passed to all log messages and may be accessed via custom formatters or filters.
 
-| Field Name | Description                                                                |
-|------------|----------------------------------------------------------------------------|
-| `cid`      | Per-session logging id used to correlate requests across a client session. |
-| `baseurl`  | Base API server URL, including http protocol.                              |
-| `method`   | HTTP method for outgoing requests, or an empty string if not applicable.   |
-| `endpoint` | API endpoint for outgoing requests, or an empty string if not applicable.  |
-| `url`      | Full API URL for outgoing requests, or an empty string if not applicable.  |
+| Field Name    | Description                                                                |
+|---------------|----------------------------------------------------------------------------|
+| `cid`         | Per-session logging id used to correlate requests across a client session. |
+| `baseurl`     | Base API server URL, including http protocol.                              |
+| `method`      | HTTP method for outgoing requests, or an empty string if not applicable.   |
+| `endpoint`    | API endpoint for outgoing requests, or an empty string if not applicable.  |
+| `url`         | Full API URL for outgoing requests, or an empty string if not applicable.  |
+| `status_code` | HTTP response status code, or an empty string if not applicable.           |
 
 ## Session IDs
 

--- a/keystone_client/http.py
+++ b/keystone_client/http.py
@@ -38,7 +38,7 @@ class HTTPBase(abc.ABC):
         verify_ssl: bool = True,
         follow_redirects: bool = False,
         max_redirects: int = 10,
-        timeout: int | None = 15,
+        timeout: int | float | None = 15,
         limits: httpx.Limits = httpx.Limits(max_connections=100, max_keepalive_connections=20),
         transport: httpx.BaseTransport | None = None,
     ) -> None:
@@ -54,10 +54,15 @@ class HTTPBase(abc.ABC):
             transport: Optional custom HTTPX transport.
         """
 
+        # Connection state
+        self._closed = False
+
+        # Logging context
         self._cid = str(uuid.uuid4())
         self._base_url = self.normalize_url(base_url)
         self._log = DefaultContextAdapter(logger, extra={"cid": self._cid, "baseurl": self._base_url, "status_code": ""})
 
+        # Underlying httpx client
         self._client = self._client_factory(
             base_url=self._base_url,
             verify=verify_ssl,
@@ -68,8 +73,6 @@ class HTTPBase(abc.ABC):
             transport=transport,
             trust_env=False,
         )
-
-        atexit.register(self.close)
 
     @property
     def base_url(self) -> str:
@@ -128,7 +131,7 @@ class HTTPBase(abc.ABC):
         json: RequestContent | None = None,
         files: RequestFiles | None = None,
         params: QueryParamTypes | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an HTTP request (sync or async depending on the implementation)."""
 
@@ -137,7 +140,7 @@ class HTTPBase(abc.ABC):
         self,
         endpoint: str,
         params: QueryParamTypes | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a GET request."""
 
@@ -147,7 +150,7 @@ class HTTPBase(abc.ABC):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a POST request."""
 
@@ -157,7 +160,7 @@ class HTTPBase(abc.ABC):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a PATCH request."""
 
@@ -167,7 +170,7 @@ class HTTPBase(abc.ABC):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a PUT request."""
 
@@ -175,13 +178,18 @@ class HTTPBase(abc.ABC):
     def http_delete(
         self,
         endpoint: str,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a DELETE request."""
 
 
 class HTTPClient(HTTPBase):
     """Synchronous HTTP Client."""
+
+    def __init__(self, *args, **kwargs) -> None:
+
+        super().__init__(*args, **kwargs)
+        atexit.register(self.close)
 
     def __enter__(self) -> 'HTTPClient':
         return self
@@ -198,8 +206,12 @@ class HTTPClient(HTTPBase):
     def close(self) -> None:
         """Close any open server connections."""
 
+        if self._closed:
+            return
+
         self._log.info("Closing HTTP session")
         self._client.close()
+        self._closed = True
 
     def send_request(
         self,
@@ -210,7 +222,7 @@ class HTTPClient(HTTPBase):
         json: RequestContent | None = None,
         files: RequestFiles | None = None,
         params: QueryParamTypes | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an HTTP request.
 
@@ -254,7 +266,7 @@ class HTTPClient(HTTPBase):
         self,
         endpoint: str,
         params: QueryParamTypes | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a GET request to an API endpoint.
 
@@ -274,7 +286,7 @@ class HTTPClient(HTTPBase):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a POST request to an API endpoint.
 
@@ -295,7 +307,7 @@ class HTTPClient(HTTPBase):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a PATCH request to an API endpoint.
 
@@ -316,7 +328,7 @@ class HTTPClient(HTTPBase):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send a PUT request to an API endpoint.
 
@@ -332,7 +344,11 @@ class HTTPClient(HTTPBase):
 
         return self.send_request("put", endpoint, json=json, files=files, timeout=timeout)
 
-    def http_delete(self, endpoint: str, timeout: int = httpx.USE_CLIENT_DEFAULT) -> httpx.Response:
+    def http_delete(
+        self,
+        endpoint: str,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
         """Send a DELETE request to an endpoint.
 
         Args:
@@ -364,8 +380,12 @@ class AsyncHTTPClient(HTTPBase):
     async def close(self) -> None:
         """Close any open server connections."""
 
+        if self._closed:
+            return
+
         self._log.info("Closing asynchronous HTTP session")
         await self._client.aclose()
+        self._closed = True
 
     async def send_request(
         self,
@@ -376,7 +396,7 @@ class AsyncHTTPClient(HTTPBase):
         json: dict | None = None,
         files: RequestFiles | None = None,
         params: QueryParamTypes | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an HTTP request.
 
@@ -420,7 +440,7 @@ class AsyncHTTPClient(HTTPBase):
         self,
         endpoint: str,
         params: QueryParamTypes | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an asynchronous GET request to an API endpoint.
 
@@ -440,7 +460,7 @@ class AsyncHTTPClient(HTTPBase):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an asynchronous POST request to an API endpoint.
 
@@ -461,7 +481,7 @@ class AsyncHTTPClient(HTTPBase):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an asynchronous PATCH request to an API endpoint.
 
@@ -482,7 +502,7 @@ class AsyncHTTPClient(HTTPBase):
         endpoint: str,
         json: RequestData | None = None,
         files: RequestFiles | None = None,
-        timeout: int = httpx.USE_CLIENT_DEFAULT,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
     ) -> httpx.Response:
         """Send an asynchronous PUT request to an API endpoint.
 
@@ -498,7 +518,11 @@ class AsyncHTTPClient(HTTPBase):
 
         return await self.send_request("put", endpoint, json=json, files=files, timeout=timeout)
 
-    async def http_delete(self, endpoint: str, timeout: int = httpx.USE_CLIENT_DEFAULT) -> httpx.Response:
+    async def http_delete(
+        self,
+        endpoint: str,
+        timeout: int | float | None = httpx.USE_CLIENT_DEFAULT,
+    ) -> httpx.Response:
         """Send an asynchronous DELETE request to an endpoint.
 
         Args:

--- a/keystone_client/http.py
+++ b/keystone_client/http.py
@@ -15,7 +15,7 @@ from typing import Literal
 from urllib.parse import urljoin, urlparse
 
 import httpx
-from httpx._types import CertTypes, QueryParamTypes, RequestContent, RequestData, RequestFiles
+from httpx._types import QueryParamTypes, RequestContent, RequestData, RequestFiles
 
 from .log import DefaultContextAdapter
 
@@ -56,7 +56,7 @@ class HTTPBase(abc.ABC):
 
         self._cid = str(uuid.uuid4())
         self._base_url = self.normalize_url(base_url)
-        self._log = DefaultContextAdapter(logger, extra={"cid": self._cid, "baseurl": self._base_url})
+        self._log = DefaultContextAdapter(logger, extra={"cid": self._cid, "baseurl": self._base_url, "status_code": ""})
 
         self._client = self._client_factory(
             base_url=self._base_url,
@@ -206,7 +206,7 @@ class HTTPClient(HTTPBase):
         method: HttpMethod,
         endpoint: str,
         *,
-        headers: dict = None,
+        headers: dict | None = None,
         json: RequestContent | None = None,
         files: RequestFiles | None = None,
         params: QueryParamTypes | None = None,
@@ -228,10 +228,10 @@ class HTTPClient(HTTPBase):
         """
 
         url = self.normalize_url(urljoin(self.base_url, endpoint))
-        self._log.info("Sending HTTP request", extra={"method": method, "endpoint": endpoint, "url": url})
+        self._log.debug("HTTP Request", extra={"method": method, "endpoint": endpoint, "url": url})
 
         application_headers = self.get_application_headers(headers)
-        return self._client.request(
+        response = self._client.request(
             method=method,
             url=url,
             headers=application_headers,
@@ -240,6 +240,15 @@ class HTTPClient(HTTPBase):
             params=params,
             timeout=timeout,
         )
+
+        self._log.info("HTTP Response", extra={
+            "method": method,
+            "endpoint": endpoint,
+            "url": url,
+            "status_code": response.status_code
+        })
+
+        return response
 
     def http_get(
         self,
@@ -363,7 +372,7 @@ class AsyncHTTPClient(HTTPBase):
         method: HttpMethod,
         endpoint: str,
         *,
-        headers: dict = None,
+        headers: dict | None = None,
         json: dict | None = None,
         files: RequestFiles | None = None,
         params: QueryParamTypes | None = None,
@@ -385,10 +394,10 @@ class AsyncHTTPClient(HTTPBase):
         """
 
         url = self.normalize_url(urljoin(self.base_url, endpoint))
-        self._log.info("Sending asynchronous HTTP request", extra={"method": method, "endpoint": endpoint, "url": url})
+        self._log.debug("Async HTTP request", extra={"method": method, "endpoint": endpoint, "url": url})
 
         application_headers = self.get_application_headers(headers)
-        return await self._client.request(
+        response = await self._client.request(
             method=method,
             url=url,
             headers=application_headers,
@@ -397,6 +406,15 @@ class AsyncHTTPClient(HTTPBase):
             params=params,
             timeout=timeout
         )
+
+        self._log.info("Async HTTP Response", extra={
+            "method": method,
+            "endpoint": endpoint,
+            "url": url,
+            "status_code": response.status_code
+        })
+
+        return response
 
     async def http_get(
         self,

--- a/keystone_client/log.py
+++ b/keystone_client/log.py
@@ -1,6 +1,6 @@
 """Components for integrating with the standard Python logging system.
 
-The `log` module defines extensions to Python’s logging framework that
+The `log` module defines extensions to Python's logging framework that
 extend log records with application-specific context. These components
 are initialized automatically with the package and are not intended
 for direct import.
@@ -29,9 +29,10 @@ class ContextFilter(logging.Filter):
         - method
         - endpoint
         - url
+        - status_code
     """
 
-    required_attr = ("cid", "baseurl", "method", "endpoint", "url")
+    required_attr = ("cid", "baseurl", "method", "endpoint", "url", "status_code")
 
     def filter(self, record: logging.LogRecord) -> Literal[True]:
         """Ensure a log record has all required contextual attributes.

--- a/tests/unit_tests/test_http/test_HTTPBase.py
+++ b/tests/unit_tests/test_http/test_HTTPBase.py
@@ -138,14 +138,3 @@ class GetApplicationHeadersMethod(TestCase):
         headers = self.http_base.get_application_headers(overrides)
 
         self.assertEqual(custom_cid, headers[HTTPBase.CID_HEADER])
-
-
-class CloseAtExit(TestCase):
-    """Test resource cleanup at application exit."""
-
-    @patch('atexit.register')
-    def test_close_registered_with_atexit(self, mock_atexit_register: MagicMock) -> None:
-        """Verify the `close` method is registered with `atexit` on initialization."""
-
-        client = DummyHTTPBase('https://example.com/')
-        mock_atexit_register.assert_called_once_with(client.close)

--- a/tests/unit_tests/test_http/test_HTTPClient.py
+++ b/tests/unit_tests/test_http/test_HTTPClient.py
@@ -78,3 +78,15 @@ class SendRequestMethod(TestCase):
         self.assertEqual(expected_method, record.method)
         self.assertEqual(expected_endpoint, record.endpoint)
         self.assertEqual(expected_url, record.url)
+
+
+
+class CloseAtExit(TestCase):
+    """Test resource cleanup at application exit."""
+
+    @patch('atexit.register')
+    def test_close_registered_with_atexit(self, mock_atexit_register: MagicMock) -> None:
+        """Verify the `close` method is registered with `atexit` on initialization."""
+
+        client = HTTPClient(base_url="https://example.com")
+        mock_atexit_register.assert_any_call(client.close)


### PR DESCRIPTION
Log records for HTTP requests have been downgraded from the `info` level to `debug`. New log records have been added for HTTP responses at the info level, which include the returned HTTP response code. This provides clearer, more effective logging when monitoring HTTP activity.

Clients have also been updated to fix a bug where connections are closed more than once. The duplicate close was harmless, but resulted in superfluous and confusing log messages.