### PR TITLE
Drops function tests from CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -4,40 +4,40 @@ on:
   workflow_call:
 
 jobs:
-  function-tests:
-    name: Function Tests
-    runs-on: ubuntu-latest
+  # function-tests:
+  #   name: Function Tests
+  #   runs-on: ubuntu-latest
 
-    services:
-      api:
-        image: docker.cloudsmith.io/better-hpc/keystone/keystone-api
-        ports:
-          - 8000:8000
+  #   services:
+  #     api:
+  #       image: docker.cloudsmith.io/better-hpc/keystone/keystone-api
+  #       ports:
+  #         - 8000:8000
 
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJson(vars.PYTHON_VERSIONS) }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ${{ fromJson(vars.PYTHON_VERSIONS) }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v6
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: false
+  #     - name: Install Poetry
+  #       uses: snok/install-poetry@v1
+  #       with:
+  #         virtualenvs-create: false
 
-      - name: Install dependencies
-        run: poetry install --with tests
+  #     - name: Install dependencies
+  #       run: poetry install --with tests
 
-      - name: Run tests
-        run: poetry run python -m unittest discover -s tests/function_tests
+  #     - name: Run tests
+  #       run: poetry run python -m unittest discover -s tests/function_tests
 
   unit-tests:
     name: Unit Tests
@@ -81,7 +81,8 @@ jobs:
   report-test-status:
     name: Report Test Status
     runs-on: ubuntu-latest
-    needs: [ unit-tests, function-tests ]
+    #needs: [ unit-tests, function-tests ]
+    needs: [ unit-tests ]
     if: always()
 
     steps:


### PR DESCRIPTION
Function testing is racking up the usage on the cloud package repository and pushing the platform to the billing limit. I'm temporarily disabling them while a performance improvement is worked on.