### PR TITLE
Introduces `whoami` method

### DIFF
--- a/keystone_client/client.py
+++ b/keystone_client/client.py
@@ -32,6 +32,11 @@ class ClientBase(abc.ABC):
     def whoami(self) -> dict:
         """Return metadata for the currently authenticated user."""
 
+    def is_authenticated(self) -> bool:
+        """Return a boolean indicating if the current session is authenticated."""
+
+        return bool(self.whoami())
+
     @staticmethod
     def _handle_identity_response(response: httpx.Response) -> dict:
         """Handle identity check responses, returning empty dict on 401.

--- a/keystone_client/client.py
+++ b/keystone_client/client.py
@@ -29,7 +29,7 @@ class ClientBase(abc.ABC):
         """Terminate the current user session."""
 
     @abc.abstractmethod
-    def is_authenticated(self) -> dict:
+    def whoami(self) -> dict:
         """Return metadata for the currently authenticated user."""
 
     @staticmethod
@@ -90,7 +90,7 @@ class KeystoneClient(ClientBase, HTTPClient):
             if exception.response.status_code != 401:
                 raise
 
-    def is_authenticated(self, timeout: int = httpx.USE_CLIENT_DEFAULT) -> dict:
+    def whoami(self, timeout: int = httpx.USE_CLIENT_DEFAULT) -> dict:
         """Return metadata for the currently authenticated user.
 
         Returns an empty dictionary if the current session is not authenticated.
@@ -145,7 +145,7 @@ class AsyncKeystoneClient(ClientBase, AsyncHTTPClient):
             if exception.response.status_code != 401:
                 raise
 
-    async def is_authenticated(self, timeout: int = httpx.USE_CLIENT_DEFAULT) -> dict:
+    async def whoami(self, timeout: int = httpx.USE_CLIENT_DEFAULT) -> dict:
         """Return metadata for the currently authenticated user.
 
         Returns an empty dictionary if the current session is not authenticated.

--- a/tests/function_tests/test_async.py
+++ b/tests/function_tests/test_async.py
@@ -24,13 +24,13 @@ class Authentication(IsolatedAsyncioTestCase):
     async def test_login_logout(self) -> None:
         """Verify users are successfully logged in/out when providing valid credentials."""
 
-        self.assertFalse(await self.client.is_authenticated())
+        self.assertFalse(await self.client.whoami())
 
         await self.client.login(API_USER, API_PASSWORD)
-        self.assertTrue(await self.client.is_authenticated())
+        self.assertTrue(await self.client.whoami())
 
         await self.client.logout()
-        self.assertFalse(await self.client.is_authenticated())
+        self.assertFalse(await self.client.whoami())
 
     async def test_incorrect_credentials(self) -> None:
         """Verify an error is raised when authenticating with incorrect credentials."""
@@ -41,9 +41,9 @@ class Authentication(IsolatedAsyncioTestCase):
     async def test_logout_unauthenticated(self) -> None:
         """Verify the `logout` method exits silently when logging out an unauthenticated user."""
 
-        self.assertFalse(await self.client.is_authenticated())
+        self.assertFalse(await self.client.whoami())
         await self.client.logout()
-        self.assertFalse(await self.client.is_authenticated())
+        self.assertFalse(await self.client.whoami())
 
     async def test_authentication_is_not_shared(self) -> None:
         """Test user authentication is tied to specific instances."""
@@ -52,8 +52,8 @@ class Authentication(IsolatedAsyncioTestCase):
         client2 = AsyncKeystoneClient(API_HOST)
 
         await client1.login(API_USER, API_PASSWORD)
-        self.assertTrue(await client1.is_authenticated())
-        self.assertFalse(await client2.is_authenticated())
+        self.assertTrue(await client1.whoami())
+        self.assertFalse(await client2.whoami())
 
         await client1.close()
         await client2.close()
@@ -75,11 +75,11 @@ class UserMetadata(IsolatedAsyncioTestCase):
     async def test_unauthenticated_user(self) -> None:
         """Verify an empty dictionary is returned for an unauthenticated user."""
 
-        self.assertEqual(dict(), await self.client.is_authenticated())
+        self.assertEqual(dict(), await self.client.whoami())
 
     async def test_authenticated_user(self) -> None:
         """Verify user metadata is returned for an authenticated user."""
 
         await self.client.login(API_USER, API_PASSWORD)
-        user_meta = await self.client.is_authenticated()
+        user_meta = await self.client.whoami()
         self.assertEqual(API_USER, user_meta['username'])

--- a/tests/function_tests/test_sync.py
+++ b/tests/function_tests/test_sync.py
@@ -24,13 +24,13 @@ class Authentication(TestCase):
     def test_login_logout(self) -> None:
         """Verify users are successfully logged in/out when providing valid credentials."""
 
-        self.assertFalse(self.client.is_authenticated())
+        self.assertFalse(self.client.whoami())
 
         self.client.login(API_USER, API_PASSWORD)
-        self.assertTrue(self.client.is_authenticated())
+        self.assertTrue(self.client.whoami())
 
         self.client.logout()
-        self.assertFalse(self.client.is_authenticated())
+        self.assertFalse(self.client.whoami())
 
     def test_incorrect_credentials(self) -> None:
         """Verify an error is raised when authenticating with incorrect credentials."""
@@ -41,9 +41,9 @@ class Authentication(TestCase):
     def test_logout_unauthenticated(self) -> None:
         """Verify the `logout` method exits silently when logging out an unauthenticated user."""
 
-        self.assertFalse(self.client.is_authenticated())
+        self.assertFalse(self.client.whoami())
         self.client.logout()
-        self.assertFalse(self.client.is_authenticated())
+        self.assertFalse(self.client.whoami())
 
     def test_authentication_is_not_shared(self) -> None:
         """Test user authentication is tied to specific instances."""
@@ -52,8 +52,8 @@ class Authentication(TestCase):
         client2 = KeystoneClient(API_HOST)
 
         client1.login(API_USER, API_PASSWORD)
-        self.assertTrue(client1.is_authenticated())
-        self.assertFalse(client2.is_authenticated())
+        self.assertTrue(client1.whoami())
+        self.assertFalse(client2.whoami())
 
         client1.close()
         client2.close()
@@ -75,11 +75,11 @@ class UserMetadata(TestCase):
     def test_unauthenticated_user(self) -> None:
         """Verify an empty dictionary is returned for an unauthenticated user."""
 
-        self.assertEqual(dict(), self.client.is_authenticated())
+        self.assertEqual(dict(), self.client.whoami())
 
     def test_authenticated_user(self) -> None:
         """Verify user metadata is returned for an authenticated user."""
 
         self.client.login(API_USER, API_PASSWORD)
-        user_meta = self.client.is_authenticated()
+        user_meta = self.client.whoami()
         self.assertEqual(API_USER, user_meta['username'])

--- a/tests/unit_tests/test_client/test_AsyncKeystoneClient.py
+++ b/tests/unit_tests/test_client/test_AsyncKeystoneClient.py
@@ -110,7 +110,7 @@ class IsAuthenticatedMethod(IsolatedAsyncioTestCase):
             return httpx.Response(200, json=expected_data)
 
         client = AsyncKeystoneClient(base_url=self.api_url, transport=httpx.MockTransport(handler))
-        result = await client.is_authenticated()
+        result = await client.whoami()
         self.assertEqual(result, expected_data)
 
     async def test_unauthenticated_response(self) -> None:
@@ -122,7 +122,7 @@ class IsAuthenticatedMethod(IsolatedAsyncioTestCase):
             return httpx.Response(401, json={"detail": "Unauthorized"})
 
         client = AsyncKeystoneClient(base_url=self.api_url, transport=httpx.MockTransport(handler))
-        result = await client.is_authenticated()
+        result = await client.whoami()
         self.assertEqual(result, {})
 
     async def test_http_error_is_raised(self) -> None:
@@ -136,4 +136,4 @@ class IsAuthenticatedMethod(IsolatedAsyncioTestCase):
         client = AsyncKeystoneClient(base_url=self.api_url, transport=httpx.MockTransport(handler))
 
         with self.assertRaises(httpx.HTTPStatusError):
-            await client.is_authenticated()
+            await client.whoami()

--- a/tests/unit_tests/test_client/test_KeystoneClient.py
+++ b/tests/unit_tests/test_client/test_KeystoneClient.py
@@ -110,7 +110,7 @@ class IsAuthenticatedMethod(TestCase):
             return httpx.Response(200, json=expected_data)
 
         client = KeystoneClient(base_url=self.api_url, transport=httpx.MockTransport(handler))
-        result = client.is_authenticated()
+        result = client.whoami()
         self.assertEqual(result, expected_data)
 
     def test_unauthenticated_response(self) -> None:
@@ -122,7 +122,7 @@ class IsAuthenticatedMethod(TestCase):
             return httpx.Response(401, json={"detail": "Unauthorized"})
 
         client = KeystoneClient(base_url=self.api_url, transport=httpx.MockTransport(handler))
-        result = client.is_authenticated()
+        result = client.whoami()
         self.assertEqual(result, {})
 
     def test_http_error_is_raised(self) -> None:
@@ -136,4 +136,4 @@ class IsAuthenticatedMethod(TestCase):
         client = KeystoneClient(base_url=self.api_url, transport=httpx.MockTransport(handler))
 
         with self.assertRaises(httpx.HTTPStatusError):
-            client.is_authenticated()
+            client.whoami()


### PR DESCRIPTION
The `is_authenticated` method previously returned a dictionary indicating the authenticated user's identity. This is slighly confusing as the method name suggests a boolean response, not a dictionary. To provide clearer functionality, the `is_authenticated` method has been modified to return a boolean and the `whoami` method has been introduced to return the current user's metadata.